### PR TITLE
Fix: Resolve TypeScript errors and improve type safety

### DIFF
--- a/playground/env.d.ts
+++ b/playground/env.d.ts
@@ -7,3 +7,12 @@ declare module '*.vue' {
   const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>
   export default component
 }
+
+declare global {
+  interface Window {
+    /** Mount the feedback widget into a container */
+    mountFeedbackWidget: (selector: string, props?: Record<string, any>) => void
+  }
+}
+
+export {}; // Add this to ensure it's a module

--- a/widget/src/components/FormContainer.vue
+++ b/widget/src/components/FormContainer.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { SubmissionType } from '#backend/types'
-import { ref, useTemplateRef } from 'vue'
+import { ref, useTemplateRef, defineEmits } from 'vue'
 
 defineProps<{ type: SubmissionType }>()
+const emit = defineEmits<{(e: 'reset'): void}>()
 // const props = defineProps<{ type: SubmissionType }>()
 const form = useTemplateRef('form')
 

--- a/widget/tsconfig.json
+++ b/widget/tsconfig.json
@@ -9,7 +9,6 @@
       "#backend/*": ["../backend/shared/*"]
     },
     "resolveJsonModule": true,
-    "types": ["vite/client"],
     "declaration": true,
     "isolatedModules": true,
     "skipLibCheck": true


### PR DESCRIPTION
This commit addresses several TypeScript issues in the widget and playground:

1. Resolves the "Cannot find type definition file for 'vite/client'" error in the widget. This was primarily fixed by ensuring dependencies are installed with `pnpm install` and by removing `vite/client` from `compilerOptions.types` in `widget/tsconfig.json`, relying on the triple-slash directive in `widget/env.d.ts`.
2. Adds the global type definition for `window.mountFeedbackWidget` to `playground/env.d.ts`, making it accessible and type-safe within the playground.
3. Improves type safety in `widget/src/components/FormContainer.vue` by declaring an intended 'reset' event using `defineEmits`.
4. Ensures that both the widget and playground pass type checking via `vue-tsc --build --noEmit` after these changes.