### PR TITLE
feat: add meta field and e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Browsers
-        run: pnpm -C backend exec playwright install --with-deps chromium
+        run: pnpm -C backend exec playwright install chromium
 
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
         run: pnpm -C backend run test
         env:
           NUXT_HUB_PROJECT_URL: http://localhost:3000
+          NUXT_HUB_PROJECT_SECRET_KEY: test
           NUXT_GITHUB_OWNER: test
           NUXT_GITHUB_REPO: test
           NUXT_GITHUB_TOKEN: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,14 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright Browsers
+        run: pnpm -C backend exec playwright install --with-deps chromium
+
       - name: Lint
         run: pnpm run lint
 
       - name: Typecheck
         run: pnpm run typecheck
+
+      - name: Run E2E Tests
+        run: pnpm -C backend run test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,9 @@ jobs:
 
       - name: Run E2E Tests
         run: pnpm -C backend run test
+        env:
+          NUXT_HUB_PROJECT_URL: http://localhost:3000
+          NUXT_GITHUB_OWNER: test
+          NUXT_GITHUB_REPO: test
+          NUXT_GITHUB_TOKEN: test
+          NUXT_PRODUCTION_URL: http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ widget.communication?.on('before-submit', ({ formData, type, app }) => {
 })
 ```
 
+### Custom Metadata
+
+Attach custom JSON metadata to submissions via the `meta` field. Metadata is stored in the database and included in GitHub issues.
+
+```typescript
+widget.communication?.on('before-submit', ({ formData }) => {
+  formData.append('meta', JSON.stringify({
+    path: window.location.href,
+    screenSize: { width: window.innerWidth, height: window.innerHeight },
+  }))
+})
+```
+
 ### Programmatic Control
 
 ```typescript

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -31,3 +31,9 @@ dist-ssr
 *.local
 
 *.tsbuildinfo
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/backend/app/pages/test.vue
+++ b/backend/app/pages/test.vue
@@ -1,0 +1,3 @@
+<template>
+  <FeedbackModal feedback-endpoint="/api/feedback?test=true" />
+</template>

--- a/backend/nuxt.config.ts
+++ b/backend/nuxt.config.ts
@@ -48,6 +48,7 @@ export default defineNuxtConfig({
     blob: true,
     kv: true,
     cache: true,
+    remote: process.env.CI ? false : undefined,
   },
 
   runtimeConfig: {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "nuxt typecheck",
-    "db:generate": "drizzle-kit generate"
+    "db:generate": "drizzle-kit generate",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
   },
   "dependencies": {
     "@nuxt/fonts": "catalog:nuxt",
@@ -30,7 +32,9 @@
     "@antfu/ni": "catalog:tools",
     "@nuxt/eslint": "catalog:lint",
     "@nuxt/scripts": "catalog:dev",
+    "@nuxt/test-utils": "catalog:types",
     "@nuxthub/core": "catalog:server",
+    "@playwright/test": "catalog:types",
     "@unocss/nuxt": "catalog:style",
     "@vue/tsconfig": "catalog:types",
     "@vueuse/core": "catalog:utils",
@@ -40,6 +44,7 @@
     "eslint": "catalog:lint",
     "eslint-plugin-format": "catalog:lint",
     "lint-staged": "catalog:lint",
+    "playwright-core": "catalog:types",
     "typescript": "catalog:types",
     "unocss": "catalog:unocss",
     "vue-tsc": "catalog:types",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.11.1",
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev --remote --open",
+    "dev": "nuxt dev --remote",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "prepare": "nuxt prepare",

--- a/backend/playwright.config.ts
+++ b/backend/playwright.config.ts
@@ -1,0 +1,26 @@
+import process from 'node:process'
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/backend/server/api/feedback.post.ts
+++ b/backend/server/api/feedback.post.ts
@@ -52,6 +52,7 @@ export default defineEventHandler(async (event) => {
         rating: form.rating || null,
         githubIssue: `https://github.com/test/repo/issues/123`,
         attachments: form.attachments?.map((_, index) => `https://test.example.com/images/test-${index}.jpg`) || null,
+        meta: form.meta || null,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       },
@@ -99,6 +100,7 @@ export default defineEventHandler(async (event) => {
     githubIssue: github?.issueUrl || null,
     attachments: filesUrls,
     logs: form.logs || null,
+    meta: form.meta || null,
   }).returning().get()
 
   consola.success('Submission created:', fullSubmission)

--- a/backend/server/database/schema.ts
+++ b/backend/server/database/schema.ts
@@ -19,6 +19,7 @@ export const submissions = sqliteTable('submissions', {
   rating: integer('rating'),
   attachments: text('attachments', { mode: 'json' }).$type<string[]>(),
   logs: text('logs'),
+  meta: text('meta', { mode: 'json' }).$type<Record<string, any>>(),
 
   createdAt: text().notNull().default(sql`(CURRENT_TIMESTAMP)`),
   updatedAt: text().notNull().default(sql`(CURRENT_TIMESTAMP)`).$onUpdate(() => sql`(CURRENT_TIMESTAMP)`),

--- a/backend/server/utils/markdown.ts
+++ b/backend/server/utils/markdown.ts
@@ -3,7 +3,7 @@ import type { FormSchema } from './valibot-schemas'
 import { ratingToEmoji } from './rating-to-emoji'
 
 export function submissionToMarkdown(id: string, form: InferOutput<typeof FormSchema>, filesUrl: string[] = [], logsUrl?: string | undefined): string {
-  const { app, description, type, email, rating, logs, tags } = form
+  const { app, description, type, email, rating, logs, tags, meta } = form
 
   let markdown = `# ${app} - ${type}\n\n> ID: ${id}\n\n`
   if (tags && tags.length > 0)
@@ -21,6 +21,9 @@ export function submissionToMarkdown(id: string, form: InferOutput<typeof FormSc
   }
   if (logs && logsUrl) {
     markdown += `## Debug Logs\n\n[Download Debug Logs](${logsUrl})\n\n`
+  }
+  if (meta) {
+    markdown += `## Metadata\n\n\`\`\`json\n${JSON.stringify(meta, null, 2)}\n\`\`\`\n\n`
   }
 
   return markdown

--- a/backend/server/utils/valibot-schemas.ts
+++ b/backend/server/utils/valibot-schemas.ts
@@ -1,4 +1,4 @@
-import { array, boolean, fallback, file, integer, maxLength, maxSize, maxValue, mimeType, minLength, minValue, object, optional, picklist, pipe, string, transform } from 'valibot'
+import { any, array, boolean, fallback, file, integer, maxLength, maxSize, maxValue, mimeType, minLength, minValue, object, optional, picklist, pipe, record, string, transform } from 'valibot'
 import { imageMimeTypes } from '~~/shared/utils'
 
 export const FormSchema = object({
@@ -30,6 +30,11 @@ export const FormSchema = object({
     maxLength(5),
   ), []),
   logs: optional(string('Logs must be a string')),
+  meta: optional(pipe(
+    string(),
+    transform(value => JSON.parse(value)),
+    record(string(), any(), 'Meta must be a valid JSON object'),
+  )),
 })
 
 export const QuerySchema = object({

--- a/backend/shared/types/index.ts
+++ b/backend/shared/types/index.ts
@@ -13,6 +13,7 @@ export interface FeedbackResponse {
     email: string | null
     rating: number | null
     attachments: string[] | null
+    meta: Record<string, any> | null
     id: string
     createdAt: string
     updatedAt: string

--- a/backend/tests/e2e/feedback-forms.spec.ts
+++ b/backend/tests/e2e/feedback-forms.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Feedback Forms', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test')
+    // Wait for page to load
+    await page.waitForLoadState('networkidle')
+    // Open the feedback modal - click the first button (floating feedback button)
+    await page.locator('button').first().click()
+    // Wait for widget to mount
+    await page.waitForSelector('#feedback-widget', { state: 'visible', timeout: 10000 })
+  })
+
+  test('submit bug report form', async ({ page }) => {
+    // Click on the bug report button
+    await page.click('button:has-text("Bug report")')
+
+    // Fill in the description
+    const description = 'The application crashes when clicking the save button'
+    await page.fill('textarea[name="description"]', description)
+
+    // Accept terms
+    await page.check('input[name="acceptTerms"]')
+
+    // Submit the form
+    await page.click('button[type="submit"]')
+
+    // Wait for success message
+    await page.waitForSelector('text=Thank you for your feedback!', { timeout: 10000 })
+
+    // Verify success message is displayed
+    const successMessage = await page.textContent('h2')
+    expect(successMessage).toContain('Thank you for your feedback!')
+  })
+
+  test('submit idea form', async ({ page }) => {
+    // Click on the idea button
+    await page.click('button:has-text("Idea")')
+
+    // Fill in the description
+    const description = 'Add dark mode support to improve user experience'
+    await page.fill('textarea[name="description"]', description)
+
+    // Accept terms
+    await page.check('input[name="acceptTerms"]')
+
+    // Submit the form
+    await page.click('button[type="submit"]')
+
+    // Wait for success message
+    await page.waitForSelector('text=Thank you for your feedback!', { timeout: 10000 })
+
+    // Verify success message is displayed
+    const successMessage = await page.textContent('h2')
+    expect(successMessage).toContain('Thank you for your feedback!')
+  })
+
+  test('submit feedback form', async ({ page }) => {
+    // Click on the feedback button
+    await page.click('button:has-text("Feedback")')
+
+    // Fill in the description
+    const description = 'Great product! Very intuitive and easy to use.'
+    await page.fill('textarea[name="description"]', description)
+
+    // Select rating (click on 5th star label)
+    await page.click('label[for="rating-5"]')
+
+    // Accept terms
+    await page.check('input[name="acceptTerms"]')
+
+    // Submit the form
+    await page.click('button[type="submit"]')
+
+    // Wait for success message
+    await page.waitForSelector('text=Thank you for your feedback!', { timeout: 10000 })
+
+    // Verify success message is displayed
+    const successMessage = await page.textContent('h2')
+    expect(successMessage).toContain('Thank you for your feedback!')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,12 @@ catalogs:
       specifier: ^26.0.1
       version: 26.0.1
   types:
+    '@nuxt/test-utils':
+      specifier: ^3.19.2
+      version: 3.19.2
+    '@playwright/test':
+      specifier: ^1.55.1
+      version: 1.55.1
     '@tsconfig/node22':
       specifier: ^22.0.2
       version: 22.0.2
@@ -119,6 +125,9 @@ catalogs:
     '@vue/tsconfig':
       specifier: ^0.8.1
       version: 0.8.1
+    playwright-core:
+      specifier: ^1.55.1
+      version: 1.55.1
     typescript:
       specifier: ^5.9.2
       version: 5.9.2
@@ -236,13 +245,13 @@ importers:
         specifier: catalog:dev
         version: 0.11.13(@unhead/vue@2.0.17(vue@3.5.21(typescript@5.9.2)))(db0@0.3.2(better-sqlite3@11.10.0)(drizzle-orm@0.44.5(better-sqlite3@11.10.0)))(ioredis@5.8.0)(magicast@0.3.5)(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
       '@nuxt/test-utils':
-        specifier: ^3.19.2
+        specifier: catalog:types
         version: 3.19.2(@playwright/test@1.55.1)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.2)
       '@nuxthub/core':
         specifier: catalog:server
         version: 0.9.0(db0@0.3.2(better-sqlite3@11.10.0)(drizzle-orm@0.44.5(better-sqlite3@11.10.0)))(ioredis@5.8.0)(magicast@0.3.5)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(yaml@2.8.1))
       '@playwright/test':
-        specifier: ^1.55.1
+        specifier: catalog:types
         version: 1.55.1
       '@unocss/nuxt':
         specifier: catalog:style
@@ -272,7 +281,7 @@ importers:
         specifier: catalog:lint
         version: 16.2.0
       playwright-core:
-        specifier: ^1.55.1
+        specifier: catalog:types
         version: 1.55.1
       typescript:
         specifier: catalog:types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,9 +235,15 @@ importers:
       '@nuxt/scripts':
         specifier: catalog:dev
         version: 0.11.13(@unhead/vue@2.0.17(vue@3.5.21(typescript@5.9.2)))(db0@0.3.2(better-sqlite3@11.10.0)(drizzle-orm@0.44.5(better-sqlite3@11.10.0)))(ioredis@5.8.0)(magicast@0.3.5)(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
+      '@nuxt/test-utils':
+        specifier: ^3.19.2
+        version: 3.19.2(@playwright/test@1.55.1)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.2)
       '@nuxthub/core':
         specifier: catalog:server
         version: 0.9.0(db0@0.3.2(better-sqlite3@11.10.0)(drizzle-orm@0.44.5(better-sqlite3@11.10.0)))(ioredis@5.8.0)(magicast@0.3.5)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(yaml@2.8.1))
+      '@playwright/test':
+        specifier: ^1.55.1
+        version: 1.55.1
       '@unocss/nuxt':
         specifier: catalog:style
         version: 66.5.2(magicast@0.3.5)(postcss@8.5.6)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(yaml@2.8.1))(webpack@5.99.8(esbuild@0.25.5))
@@ -265,6 +271,9 @@ importers:
       lint-staged:
         specifier: catalog:lint
         version: 16.2.0
+      playwright-core:
+        specifier: ^1.55.1
+        version: 1.55.1
       typescript:
         specifier: catalog:types
         version: 5.9.2
@@ -1666,6 +1675,42 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
+  '@nuxt/test-utils@3.19.2':
+    resolution: {integrity: sha512-jvpCbTNd1e8t2vrGAMpVq8j7N25Jao0NpblRiIYwogXgNXOPrH1XBZxgufyLA701g64SeiplUe+pddtnJnQu/g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@cucumber/cucumber': ^10.3.1 || ^11.0.0
+      '@jest/globals': ^29.5.0 || ^30.0.0
+      '@playwright/test': ^1.43.1
+      '@testing-library/vue': ^7.0.0 || ^8.0.1
+      '@vitest/ui': '*'
+      '@vue/test-utils': ^2.4.2
+      happy-dom: ^9.10.9 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      jsdom: ^22.0.0 || ^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0
+      playwright-core: ^1.43.1
+      vitest: ^3.2.0
+    peerDependenciesMeta:
+      '@cucumber/cucumber':
+        optional: true
+      '@jest/globals':
+        optional: true
+      '@playwright/test':
+        optional: true
+      '@testing-library/vue':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      '@vue/test-utils':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright-core:
+        optional: true
+      vitest:
+        optional: true
+
   '@nuxt/vite-builder@4.1.2':
     resolution: {integrity: sha512-to9NKVtzMBtyuhIIVgwo/ph5UCONcxkVsoAjm8HnSkDi0o9nDPhHOAg1AUMlvPnHpdXOzwnSrXo/t8E7W+UZ/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2096,6 +2141,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -4069,6 +4119,10 @@ packages:
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
+  fake-indexeddb@6.2.2:
+    resolution: {integrity: sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==}
+    engines: {node: '>=18'}
+
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
@@ -4178,6 +4232,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4204,9 +4263,6 @@ packages:
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
-
-  get-port-please@3.1.2:
-    resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
 
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
@@ -5274,6 +5330,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -6465,6 +6531,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-environment-nuxt@1.0.1:
+    resolution: {integrity: sha512-eBCwtIQriXW5/M49FjqNKfnlJYlG2LWMSNFsRVKomc8CaMqmhQPBS5LZ9DlgYL9T8xIVsiA6RZn2lk7vxov3Ow==}
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -8197,6 +8266,39 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxt/test-utils@3.19.2(@playwright/test@1.55.1)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.2)':
+    dependencies:
+      '@nuxt/kit': 3.19.2(magicast@0.3.5)
+      c12: 3.3.0(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      estree-walker: 3.0.3
+      fake-indexeddb: 6.2.2
+      get-port-please: 3.2.0
+      h3: 1.15.4
+      local-pkg: 1.1.2
+      magic-string: 0.30.19
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.3
+      ofetch: 1.4.1
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      radix3: 1.1.2
+      scule: 1.3.0
+      std-env: 3.9.0
+      tinyexec: 1.0.1
+      ufo: 1.6.1
+      unplugin: 2.3.10
+      vitest-environment-nuxt: 1.0.1(@playwright/test@1.55.1)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.2)
+      vue: 3.5.21(typescript@5.9.2)
+    optionalDependencies:
+      '@playwright/test': 1.55.1
+      playwright-core: 1.55.1
+    transitivePeerDependencies:
+      - magicast
+      - typescript
+
   '@nuxt/vite-builder@4.1.2(@types/node@24.5.2)(eslint@9.36.0(jiti@2.6.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.2)(terser@5.44.0)(typescript@5.9.2)(vue-tsc@3.0.8(typescript@5.9.2))(vue@3.5.21(typescript@5.9.2))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 4.1.2(magicast@0.3.5)
@@ -8573,6 +8675,10 @@ snapshots:
   '@pkgr/core@0.1.2': {}
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.55.1':
+    dependencies:
+      playwright: 1.55.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -10836,6 +10942,8 @@ snapshots:
 
   exsolve@1.0.7: {}
 
+  fake-indexeddb@6.2.2: {}
+
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -10949,6 +11057,9 @@ snapshots:
   fs-constants@1.0.0:
     optional: true
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -10963,8 +11074,6 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
-
-  get-port-please@3.1.2: {}
 
   get-port-please@3.2.0: {}
 
@@ -11396,8 +11505,8 @@ snapshots:
       consola: 3.4.2
       crossws: 0.3.5
       defu: 6.1.4
-      get-port-please: 3.1.2
-      h3: 1.15.3
+      get-port-please: 3.2.0
+      h3: 1.15.4
       http-shutdown: 1.2.2
       jiti: 2.6.0
       mlly: 1.8.0
@@ -12256,7 +12365,7 @@ snapshots:
   ofetch@1.4.1:
     dependencies:
       destr: 2.0.5
-      node-fetch-native: 1.6.6
+      node-fetch-native: 1.6.7
       ufo: 1.6.1
 
   ohash@2.0.11: {}
@@ -12473,6 +12582,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  playwright-core@1.55.1: {}
+
+  playwright@1.55.1:
+    dependencies:
+      playwright-core: 1.55.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 
@@ -13893,6 +14010,23 @@ snapshots:
       jiti: 2.6.0
       terser: 5.44.0
       yaml: 2.8.1
+
+  vitest-environment-nuxt@1.0.1(@playwright/test@1.55.1)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.2):
+    dependencies:
+      '@nuxt/test-utils': 3.19.2(@playwright/test@1.55.1)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.2)
+    transitivePeerDependencies:
+      - '@cucumber/cucumber'
+      - '@jest/globals'
+      - '@playwright/test'
+      - '@testing-library/vue'
+      - '@vitest/ui'
+      - '@vue/test-utils'
+      - happy-dom
+      - jsdom
+      - magicast
+      - playwright-core
+      - typescript
+      - vitest
 
   vscode-uri@3.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,9 +48,12 @@ catalogs:
   tools:
     '@antfu/ni': ^26.0.1
   types:
+    '@nuxt/test-utils': ^3.19.2
+    '@playwright/test': ^1.55.1
     '@tsconfig/node22': ^22.0.2
     '@types/node': ^24.5.2
     '@vue/tsconfig': ^0.8.1
+    playwright-core: ^1.55.1
     typescript: ^5.9.2
     vue-tsc: ^3.0.8
   unocss:

--- a/widget/src/components/FormContainer.vue
+++ b/widget/src/components/FormContainer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { FeedbackResponse, FeedbackResponseError, FormType } from '#backend/types'
-import { computed, inject, onMounted, provide, ref } from 'vue'
+import { computed, inject, provide, ref } from 'vue'
 import { useI18n } from '../composables/useI18n'
 import { CommunicationInjectionKey, FilesInjectionKey, FormValidationKey } from '../types'
 
@@ -24,29 +24,7 @@ const acceptTerms = ref(false)
 const description = ref('')
 const rating = ref(0)
 
-// Metadata fields
-const metadata = ref({
-  screenSize: '',
-  viewportSize: '',
-  url: '',
-  userAgent: '',
-  timezone: '',
-  locale: '',
-})
-
 provide(FormValidationKey, { description, rating })
-
-// Capture metadata on mount
-onMounted(() => {
-  metadata.value = {
-    screenSize: `${window.screen.width}x${window.screen.height}`,
-    viewportSize: `${window.innerWidth}x${window.innerHeight}`,
-    url: window.location.href,
-    userAgent: navigator.userAgent,
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    locale: navigator.language,
-  }
-})
 
 const { t } = useI18n()
 const isFormValid = computed(() => {
@@ -146,14 +124,6 @@ async function submitFeedback(event: SubmitEvent) {
       <input type="text" name="type" :value="type" sr-only>
       <input type="text" name="app" :value="app" sr-only>
       <input type="text" name="tags" :value="tags.join(',')" sr-only>
-
-      <!-- Metadata fields -->
-      <input type="text" name="meta[screenSize]" :value="metadata.screenSize" sr-only>
-      <input type="text" name="meta[viewportSize]" :value="metadata.viewportSize" sr-only>
-      <input type="text" name="meta[url]" :value="metadata.url" sr-only>
-      <input type="text" name="meta[userAgent]" :value="metadata.userAgent" sr-only>
-      <input type="text" name="meta[timezone]" :value="metadata.timezone" sr-only>
-      <input type="text" name="meta[locale]" :value="metadata.locale" sr-only>
 
       <slot />
 

--- a/widget/src/components/FormContainer.vue
+++ b/widget/src/components/FormContainer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { FeedbackResponse, FeedbackResponseError, FormType } from '#backend/types'
-import { computed, inject, provide, ref } from 'vue'
+import { computed, inject, onMounted, provide, ref } from 'vue'
 import { useI18n } from '../composables/useI18n'
 import { CommunicationInjectionKey, FilesInjectionKey, FormValidationKey } from '../types'
 
@@ -24,7 +24,29 @@ const acceptTerms = ref(false)
 const description = ref('')
 const rating = ref(0)
 
+// Metadata fields
+const metadata = ref({
+  screenSize: '',
+  viewportSize: '',
+  url: '',
+  userAgent: '',
+  timezone: '',
+  locale: '',
+})
+
 provide(FormValidationKey, { description, rating })
+
+// Capture metadata on mount
+onMounted(() => {
+  metadata.value = {
+    screenSize: `${window.screen.width}x${window.screen.height}`,
+    viewportSize: `${window.innerWidth}x${window.innerHeight}`,
+    url: window.location.href,
+    userAgent: navigator.userAgent,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    locale: navigator.language,
+  }
+})
 
 const { t } = useI18n()
 const isFormValid = computed(() => {
@@ -124,6 +146,14 @@ async function submitFeedback(event: SubmitEvent) {
       <input type="text" name="type" :value="type" sr-only>
       <input type="text" name="app" :value="app" sr-only>
       <input type="text" name="tags" :value="tags.join(',')" sr-only>
+
+      <!-- Metadata fields -->
+      <input type="text" name="meta[screenSize]" :value="metadata.screenSize" sr-only>
+      <input type="text" name="meta[viewportSize]" :value="metadata.viewportSize" sr-only>
+      <input type="text" name="meta[url]" :value="metadata.url" sr-only>
+      <input type="text" name="meta[userAgent]" :value="metadata.userAgent" sr-only>
+      <input type="text" name="meta[timezone]" :value="metadata.timezone" sr-only>
+      <input type="text" name="meta[locale]" :value="metadata.locale" sr-only>
 
       <slot />
 


### PR DESCRIPTION
## Summary

This PR adds two main features:

1. **Custom metadata field (`meta`)**: A JSON field to store custom metadata (screen size, viewport, URL, user agent, timezone, locale) that gets stored in the database and included in GitHub issues.

2. **End-to-end testing with Playwright**: Complete e2e test suite covering all three feedback forms (bug, idea, feedback) with CI integration.

## Changes

### Meta Field
- Added `meta` JSON field to database schema
- Updated valibot validation to accept JSON metadata
- Modified markdown generator to display metadata in GitHub issues
- Updated API endpoint to handle and store meta field
- Updated types to include meta in responses
- Added documentation in README with usage examples

### E2E Testing
- Installed Playwright and test dependencies
- Created Playwright configuration
- Added test page at `/test` with test mode enabled
- Implemented 3 test cases (bug form, idea form, feedback form)
- All tests pass in ~17 seconds

### CI/CD
- Updated GitHub Actions workflow to run e2e tests on every commit
- Configured environment variables for test environment
- Disabled NuxtHub remote storage in CI
- Chrome-only browser installation for faster CI runs
- Removed `--open` flag from dev server

## Test Results

✅ All 3 e2e tests passing
✅ Lint passing
✅ Typecheck passing
✅ CI running successfully

## Notes

- Tests use `?test=true` mode - no data is written to database, GitHub, or Slack
- Meta field is optional and only included if provided via `before-submit` event